### PR TITLE
skip rdock

### DIFF
--- a/bgruening_skip_list
+++ b/bgruening_skip_list
@@ -1,2 +1,3 @@
 diff.xml
 prepare_box.xml
+rdock_macros.xml


### PR DESCRIPTION
We are using rxdock for now. Is that the correct way to skip the entire folder?