### PR TITLE
Fix IUC: sync fork

### DIFF
--- a/.github/workflows/tools-iuc.yml
+++ b/.github/workflows/tools-iuc.yml
@@ -16,6 +16,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # used for the skip lists
     - name: Checkout tools-iuc
       uses: actions/checkout@v2
       with:
@@ -66,12 +67,15 @@ jobs:
 
         echo "Pulling latest from upstream..."
         git fetch --all
+        git pull upstream master 
+        git push origin master 
         
         REPOS=$(planemo ci_find_repos tools/)
         echo $REPOS
         for REPO in $REPOS; do
           # git checkout upstream/master
           echo $REPO
+
           # checkout branch, create if it doesn't exist
           if [[ $(gh pr list --limit 10000 | grep planemo-autoupdate:$REPO.\s*OPEN) ]]
           then

--- a/.github/workflows/tools-iuc.yml
+++ b/.github/workflows/tools-iuc.yml
@@ -73,7 +73,6 @@ jobs:
         REPOS=$(planemo ci_find_repos tools/)
         echo $REPOS
         for REPO in $REPOS; do
-          # git checkout upstream/master
           echo $REPO
 
           # checkout branch, create if it doesn't exist


### PR DESCRIPTION
the fork `planemo-autoupdate/tools-iuc` is currently not synced.

so the for loop will include deprecated tools (and exclude new tools). For these the `git checkout -b $REPO upstream/master` will use the newest upstream branch where the tool dir is absent leading to an error. This should fix the current failure of the bot.

I guess the same needs to be done for the other repos, but I won't be able to do so.

in the future we might try to deleted branches and PR if tools are deprecated