### PR TITLE
only target OPEN PR for OLD_TITLE

### DIFF
--- a/.github/workflows/iwc.yml
+++ b/.github/workflows/iwc.yml
@@ -100,7 +100,7 @@ jobs:
 
             if [[ $(git diff) ]]
             then
-              OLD_TITLE=$(gh pr list --limit 10000 | grep planemo-autoupdate:$REPO | cut -f 2)
+              OLD_TITLE=$(gh pr list --limit 10000 | grep planemo-autoupdate:$REPO.\s*OPEN | cut -f 2)
               if [[ $OLD_TITLE ]] # just need to update PR title
               then
                 PR_EXISTS=1


### PR DESCRIPTION
CI is failing:
![image](https://user-images.githubusercontent.com/30404086/196696296-a153f8cf-9a5c-4364-874b-798a27397f8d.png)
I am not sure this solves the issue but for me it is strange to first check if a PR is opened with:
https://github.com/planemo-autoupdate/autoupdate/blob/12705e2f0f0f32fb9747d7905170de288a43805d/.github/workflows/iwc.yml#L81
And then use: `OLD_TITLE=...` without the OPEN. This would cause the PR_EXISTS to 1 because there is a old closed PR opened and this may cause the bug...