### PR TITLE
add lines to get planemo-autoupdate/iwc at the level of galaxyproject/iwc main

### DIFF
--- a/.github/workflows/iwc.yml
+++ b/.github/workflows/iwc.yml
@@ -67,6 +67,8 @@ jobs:
 
         echo "Pulling latest from upstream..."
         git fetch --all
+        git pull upstream master 
+        git push origin master 
         
         REPOS=$(planemo ci_find_repos workflows/)
         echo $REPOS


### PR DESCRIPTION
Currently planemo-autoupdate/iwc 209 commits behind galaxyproject/iwc: https://github.com/planemo-autoupdate/iwc
This is because there is no pull...
I added these 2 lines so the autoupdate is done on the last version...