### PR TITLE
remove extra space in worflow yaml

### DIFF
--- a/.github/workflows/galaxycompchem.yml
+++ b/.github/workflows/galaxycompchem.yml
@@ -45,7 +45,6 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-
         echo "Installing planemo..."
         pip3 install https://github.com/galaxyproject/planemo/archive/refs/heads/master.zip
 

--- a/.github/workflows/galaxycompchem.yml
+++ b/.github/workflows/galaxycompchem.yml
@@ -45,7 +45,7 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-        
+
         echo "Installing planemo..."
         pip3 install https://github.com/galaxyproject/planemo/archive/refs/heads/master.zip
 

--- a/.github/workflows/iwc.yml
+++ b/.github/workflows/iwc.yml
@@ -45,7 +45,7 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-        
+
         echo "Installing planemo..."
         # pip3 install planemo
         pip3 install https://github.com/galaxyproject/planemo/archive/refs/heads/master.zip

--- a/.github/workflows/iwc.yml
+++ b/.github/workflows/iwc.yml
@@ -45,7 +45,6 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-
         echo "Installing planemo..."
         # pip3 install planemo
         pip3 install https://github.com/galaxyproject/planemo/archive/refs/heads/master.zip

--- a/.github/workflows/tools-iuc.yml
+++ b/.github/workflows/tools-iuc.yml
@@ -46,7 +46,7 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-        
+
         echo "Installing planemo..."
         pip3 install https://github.com/galaxyproject/planemo/archive/refs/heads/master.zip
 

--- a/.github/workflows/tools-iuc.yml
+++ b/.github/workflows/tools-iuc.yml
@@ -46,7 +46,6 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-
         echo "Installing planemo..."
         pip3 install https://github.com/galaxyproject/planemo/archive/refs/heads/master.zip
 


### PR DESCRIPTION
In the last action there was:
```
The workflow is not valid. .github/workflows/galaxycompchem.yml: While scanning a literal block scalar, found extra spaces in first line.
```

This PR is supposed to fix it.