### PR TITLE
Improve autoupdate

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -186,6 +186,8 @@ jobs:
                 if [ "$PR_STATUS" = "CLOSED" ]; then
                   gh pr reopen "$PR_NUMBER"
                 fi
+                # Comment on the PR
+                gh pr comment "$PR_NUMBER" --body "There are new updates, they have been integrated to the PR, check the file diff."
               else # we need to create a PR
                 echo "Creating a PR..."
                 gh pr create --base "${{ matrix.upstream_repo_branch }}" --head "planemo-autoupdate:$REPO" --title "$TITLE" --repo "${{ matrix.upstream_repo_owner}}/${{ matrix.upstream_repo_name }}" --body-file "${{ github.workspace }}/body.txt"

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -84,13 +84,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
+          errors=""
           REPOS=$(planemo ci_find_repos "${{ matrix.upstream_repo_dir }}")
           for REPO in $REPOS; do
             echo $REPO
             # First try to update
             echo "Running autoupdate command..."
             cd "$REPO"
-            planemo autoupdate . --skiplist "${{ github.workspace }}/autoupdate/${{ matrix.upstream_repo_owner }}_${{ matrix.upstream_repo_name }}_skip_list" > "${{ github.workspace }}/autoupdate.log"
+            # This may fail
+            planemo autoupdate . --skiplist "${{ github.workspace }}/autoupdate/${{ matrix.upstream_repo_owner }}_${{ matrix.upstream_repo_name }}_skip_list" > "${{ github.workspace }}/autoupdate.log" || errors="$error\nCannot autoupdate $REPO"
             rm -f tool_test_output.* tools.yml
             cd -
             # Check if it changed something
@@ -185,11 +187,14 @@ jobs:
                   NEW_TITLE="$(echo "$OLD_TITLE" | cut --complement -f 7 -d ' ') $(echo "$TITLE" | cut -f 7 -d ' ')"
                 fi
                 if [ "$NEW_TITLE" != "$OLD_TITLE" ]; then
-                  gh pr edit "$PR_NUMBER" -t "$NEW_TITLE"
+                  # This may fail if for example the PR was opened by someone else like
+                  # https://github.com/bgruening/galaxytools/pull/1353
+                  gh pr edit "$PR_NUMBER" -t "$NEW_TITLE" || errors="$error\nCannot change title of PR $PR_NUMBER for $REPO"
                 fi
                 # If the PR is closed, we need to reopen it.
                 if [ "$PR_STATUS" = "CLOSED" ]; then
-                  gh pr reopen "$PR_NUMBER"
+                  # This may fail
+                  gh pr reopen "$PR_NUMBER" || errors="$error\nCannot reopen PR $PR_NUMBER for $REPO"
                 fi
                 # Comment on the PR
                 gh pr comment "$PR_NUMBER" --body "There are new updates, they have been integrated to the PR, check the file diff."
@@ -199,4 +204,9 @@ jobs:
               fi
             fi
           done
+          if [ ! -z "$error" ]; then
+            echo "ERRORS OCCURED DURING AUTOUPDATE:"
+            echo -e $error
+            exit 1
+          fi
         working-directory: ./tools_repo

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -92,7 +92,7 @@ jobs:
             echo "Running autoupdate command..."
             cd "$REPO"
             # This may fail
-            planemo autoupdate . --skiplist "${{ github.workspace }}/autoupdate/${{ matrix.upstream_repo_owner }}_${{ matrix.upstream_repo_name }}_skip_list" > "${{ github.workspace }}/autoupdate.log" || errors="$error\nCannot autoupdate $REPO"
+            planemo autoupdate . --skiplist "${{ github.workspace }}/autoupdate/${{ matrix.upstream_repo_owner }}_${{ matrix.upstream_repo_name }}_skip_list" > "${{ github.workspace }}/autoupdate.log" || errors="${errors}\nCannot autoupdate $REPO"
             rm -f tool_test_output.* tools.yml
             cd -
             # Check if it changed something
@@ -184,12 +184,12 @@ jobs:
                 if [ "$NEW_TITLE" != "$OLD_TITLE" ]; then
                   # This may fail if for example the PR was opened by someone else like
                   # https://github.com/bgruening/galaxytools/pull/1353
-                  gh pr edit "$PR_NUMBER" -t "$NEW_TITLE" || errors="$error\nCannot change title of PR $PR_NUMBER for $REPO"
+                  gh pr edit "$PR_NUMBER" -t "$NEW_TITLE" || errors="${errors}\nCannot change title of PR $PR_NUMBER for $REPO"
                 fi
                 # If the PR is closed, we need to reopen it.
                 if [ "$PR_STATUS" = "CLOSED" ]; then
                   # This may fail
-                  gh pr reopen "$PR_NUMBER" || errors="$error\nCannot reopen PR $PR_NUMBER for $REPO"
+                  gh pr reopen "$PR_NUMBER" || errors="${errors}\nCannot reopen PR $PR_NUMBER for $REPO"
                 fi
                 # Comment on the PR
                 gh pr comment "$PR_NUMBER" --body "There are new updates, they have been integrated to the PR, check the file diff."
@@ -199,9 +199,9 @@ jobs:
               fi
             fi
           done
-          if [ ! -z "$error" ]; then
+          if [ ! -z "$errors" ]; then
             echo "ERRORS OCCURED DURING AUTOUPDATE:"
-            echo -e $error
+            echo -e $errors
             exit 1
           fi
         working-directory: ./tools_repo

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -124,15 +124,20 @@ jobs:
               # Check if a closed PR exists with the same title
               if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:"); then
                 echo "Found a closed PR with title: $TITLE"
-                OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
-                PR_EXISTS=1
-                PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
-                PR_STATUS="CLOSED"
                 if [ "$(git branch -a --list "origin/$REPO")" != "" ]; then
                   # The branch still exists and the PR should be reopened only if there is a new change
+                  OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
+                  PR_EXISTS=1
+                  PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
+                  PR_STATUS="CLOSED"
                   DIFF_BRANCH="origin/$REPO"
                 else
-                  # The branch does not exists anymore so any change should reopen the PR
+                  # The branch does not exists anymore let's do like if the PR were not existing:
+                  echo "The branch does not exists anymore, ignore PR."
+                  OLD_TITLE=
+                  PR_EXISTS=0
+                  PR_NUMBER=
+                  PR_STATUS=
                   DIFF_BRANCH="upstream/${{ matrix.upstream_repo_branch }}"
                 fi
               else

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -150,8 +150,8 @@ jobs:
             if ! git diff $DIFF_BRANCH --quiet $FILE_TO_CHECK; then
               echo "There are changes"
               if [ "$PR_EXISTS" -eq 1 ]; then
-                # Check if there was manual commits
-                LAST_AUTHOR=$(git log -1 --pretty=format:'%an')
+                # Check if the last commit of the existing branch was manual
+                LAST_AUTHOR=$(git log -1 --pretty=format:'%an' $DIFF_BRANCH)
                 if [ "$LAST_AUTHOR" != "planemo-autoupdate" ]; then
                   # There were manual commits we do not do anything
                   gh pr comment "$PR_NUMBER" --body "There are new updates, if you want to integrate them, close the PR and delete branch."

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -126,20 +126,15 @@ jobs:
               # Check if a closed PR exists with the same title
               if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:"); then
                 echo "Found a closed PR with title: $TITLE"
+                OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
+                PR_EXISTS=1
+                PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
+                PR_STATUS="CLOSED"
                 if [ "$(git branch -a --list "origin/$REPO")" != "" ]; then
                   # The branch still exists and the PR should be reopened only if there is a new change
-                  OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
-                  PR_EXISTS=1
-                  PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
-                  PR_STATUS="CLOSED"
                   DIFF_BRANCH="origin/$REPO"
                 else
-                  # The branch does not exists anymore let's do like if the PR were not existing:
-                  echo "The branch does not exists anymore, ignore PR."
-                  OLD_TITLE=
-                  PR_EXISTS=0
-                  PR_NUMBER=
-                  PR_STATUS=
+                  # The branch does not exists anymore so any change should reopen the PR
                   DIFF_BRANCH="upstream/${{ matrix.upstream_repo_branch }}"
                 fi
               else

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -179,7 +179,9 @@ jobs:
                 else # newer PRs
                   NEW_TITLE="$(echo "$OLD_TITLE" | cut --complement -f 7 -d ' ') $(echo "$TITLE" | cut -f 7 -d ' ')"
                 fi
-                gh pr edit "$PR_NUMBER" -t "$NEW_TITLE"
+                if [ "$NEW_TITLE" != "$OLD_TITLE" ]; then
+                  gh pr edit "$PR_NUMBER" -t "$NEW_TITLE"
+                fi
                 # If the PR is closed, we need to reopen it.
                 if [ "$PR_STATUS" = "CLOSED" ]; then
                   gh pr reopen "$PR_NUMBER"


### PR DESCRIPTION
Update:
- I prevent changing PR title if identical, for example in https://github.com/galaxyproject/iwc/pull/511
- I comment the PR when there is a change (I prefer but if you think this makes too much noise we can remove this).
- Fix a bug in the way to check if there are manual commits
- Use error handling (or at least I think this should do this).