### PR TITLE
Improve autoupdate round 2

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -116,9 +116,9 @@ jobs:
             # We cannot use the -A option of `gh pr list` because the PR author changes with the Personal Access Token used,
             # so we filter on the 3rd output field (headRefName, i.e. remote_repository:branch).
             if gh_pr_list_out=$(gh pr list --search "head:$REPO" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:$REPO\t"); then
-              OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
+              OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2 | head -n 1)
               PR_EXISTS=1
-              PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
+              PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1 | head -n 1)
               PR_STATUS="OPENED"
               echo "PR exists and is opened"
               DIFF_BRANCH="origin/$REPO"
@@ -126,9 +126,9 @@ jobs:
               # Check if a closed PR exists with the same title
               if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:"); then
                 echo "Found a closed PR with title: $TITLE"
-                OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
+                OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2 | head -n 1)
                 PR_EXISTS=1
-                PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
+                PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1 | head -n 1)
                 PR_STATUS="CLOSED"
                 if [ "$(git branch -a --list "origin/$REPO")" != "" ]; then
                   # The branch still exists and the PR should be reopened only if there is a new change

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -116,9 +116,9 @@ jobs:
             # We cannot use the -A option of `gh pr list` because the PR author changes with the Personal Access Token used,
             # so we filter on the 3rd output field (headRefName, i.e. remote_repository:branch).
             if gh_pr_list_out=$(gh pr list --search "head:$REPO" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:$REPO\t"); then
-              OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2 | head -n 1)
+              OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
               PR_EXISTS=1
-              PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1 | head -n 1)
+              PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
               PR_STATUS="OPENED"
               echo "PR exists and is opened"
               DIFF_BRANCH="origin/$REPO"
@@ -126,9 +126,9 @@ jobs:
               # Check if a closed PR exists with the same title
               if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:"); then
                 echo "Found a closed PR with title: $TITLE"
-                OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2 | head -n 1)
+                OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
                 PR_EXISTS=1
-                PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1 | head -n 1)
+                PR_NUMBER=$(echo "$gh_pr_list_out" | cut -f 1)
                 PR_STATUS="CLOSED"
                 if [ "$(git branch -a --list "origin/$REPO")" != "" ]; then
                   # The branch still exists and the PR should be reopened only if there is a new change

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -198,7 +198,7 @@ jobs:
                 gh pr create --base "${{ matrix.upstream_repo_branch }}" --head "planemo-autoupdate:$REPO" --title "$TITLE" --repo "${{ matrix.upstream_repo_owner}}/${{ matrix.upstream_repo_name }}" --body-file "${{ github.workspace }}/body.txt"
               fi
             else
-              echo "No changes compared to current PR"
+              echo "No changes compared to $DIFF_BRANCH"
               # clean up for the next repo
               git checkout -- .
             fi

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -124,7 +124,7 @@ jobs:
               DIFF_BRANCH="origin/$REPO"
             else
               # Check if a closed PR exists with the same title
-              if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:"); then
+              if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:" | head -n 1); then
                 echo "Found a closed PR with title: $TITLE"
                 OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
                 PR_EXISTS=1

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -197,6 +197,10 @@ jobs:
                 echo "Creating a PR..."
                 gh pr create --base "${{ matrix.upstream_repo_branch }}" --head "planemo-autoupdate:$REPO" --title "$TITLE" --repo "${{ matrix.upstream_repo_owner}}/${{ matrix.upstream_repo_name }}" --body-file "${{ github.workspace }}/body.txt"
               fi
+            else
+              echo "No changes compared to current PR"
+              # clean up for the next repo
+              git checkout -- .
             fi
           done
           if [ ! -z "$errors" ]; then


### PR DESCRIPTION
Looking at the logs there are at least 2 things to fix:
- deal with cases when multiple PR titles match
- clean repo if the current PR has the same changes as after autoupdate.