### PR TITLE
Improve autoupdate round 3

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -217,6 +217,15 @@ jobs:
           if [ ! -z "$errors" ]; then
             echo "ERRORS OCCURED DURING AUTOUPDATE:"
             echo -e $errors
+            # Write these errors to an issue
+            body="$(date), there were errors when running autoupdate\n\n$errors"
+            echo -e $body > body.txt
+            if gh_issue_list=$(gh issue list --author "planemo-autoupdate" | grep -P "^\d+\t[^\t]+\tAutoupdate errors\t"); then
+              gh issue comment $(echo "$gh_issue_list" | cut -f 1 | head -n 1) -F body.txt
+            else
+              gh issue create -t "Autoupdate errors" -F body.txt
+            fi
+            rm body.txt
             exit 1
           fi
         working-directory: ./tools_repo

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -92,7 +92,7 @@ jobs:
             echo "Running autoupdate command..."
             cd "$REPO"
             # This may fail
-            planemo autoupdate . --skiplist "${{ github.workspace }}/autoupdate/${{ matrix.upstream_repo_owner }}_${{ matrix.upstream_repo_name }}_skip_list" > "${{ github.workspace }}/autoupdate.log" || errors="${errors}\nCannot autoupdate $REPO"
+            planemo autoupdate . --skiplist "${{ github.workspace }}/autoupdate/${{ matrix.upstream_repo_owner }}_${{ matrix.upstream_repo_name }}_skip_list" 2>&1 1> "${{ github.workspace }}/autoupdate.log" | tee "${{ github.workspace }}/autoupdate.err" || errors="${errors}\nCannot autoupdate $REPO, last line of stderr is\n$(tail -n 1 "${{ github.workspace }}/autoupdate.err")"
             rm -f tool_test_output.* tools.yml
             cd -
             # Check if it changed something

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -124,7 +124,9 @@ jobs:
               DIFF_BRANCH="origin/$REPO"
             else
               # Check if a closed PR exists with the same title
-              if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:" | head -n 1); then
+              if gh_pr_list_out=$(gh pr list --search "is:closed is:unmerged '$TITLE' in:title" | grep -P "^\d+\t[^\t]+\tplanemo-autoupdate:"); then
+                # Only take the first one
+                gh_pr_list_out=$(echo "$gh_pr_list_out" | head -n 1)
                 echo "Found a closed PR with title: $TITLE"
                 OLD_TITLE=$(echo "$gh_pr_list_out" | cut -f 2)
                 PR_EXISTS=1

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -152,6 +152,15 @@ jobs:
               fi
             fi
             if ! git diff $DIFF_BRANCH --quiet $FILE_TO_CHECK; then
+              # Check if it is only the date in workflows
+              if [[ "$REPO" = "workflows/"* ]]; then
+                if [ $(git diff --numstat $DIFF_BRANCH $FILE_TO_CHECK | cut -f 1) = "1" ]; then
+                  echo "A single line was added, probably the date, nothing is changed"
+                  # clean up for the next repo
+                  git checkout -- .
+                  continue
+                fi
+              fi
               echo "There are changes"
               if [ "$PR_EXISTS" -eq 1 ]; then
                 # Check if the last commit of the existing branch was manual

--- a/pr_text.py
+++ b/pr_text.py
@@ -56,6 +56,11 @@ text.append(
     "For any comments, queries or criticism about the bot, not related to the tool being updated in this PR, please create an issue [here](https://github.com/planemo-autoupdate/autoupdate/issues/new)."
 )
 
+# Add info on the strategy
+text.append("\nIf you want to skip this change, close this PR without deleting the branch. It will be reopened if another change is detected.")
+text.append("Any commit from another author than 'planemo-autoupdate' will prevent more auto-updates.")
+text.append("To ignore manual changes and allow autoupdates, delete the branch.")
+
 with open(args.out, "w") as f:
     f.write("\n\n".join(text))
 

--- a/pr_text_iwc.py
+++ b/pr_text_iwc.py
@@ -28,15 +28,18 @@ text.append(
 )
 
 with open(args.log) as f:
+    already_reported = {}
     for line in f.readlines():
         if " -> " in line:
             words = line.split()
             from_version = words[1]
             to_version = words[3]
-            text.append(f"* `{from_version}` should be updated to `{to_version}`")
-            new_changelog_lines.append(
-                f"- `{from_version}` was updated to `{to_version}`"
-            )
+            if to_version not in already_reported.get(from_version, []):
+                text.append(f"* `{from_version}` should be updated to `{to_version}`")
+                new_changelog_lines.append(
+                    f"- `{from_version}` was updated to `{to_version}`"
+                )
+                already_reported[from_version] = already_reported.get(from_version, []) + [to_version]
         if "The workflow release number has been updated" in line:
             release_line = line
             text.append(f"\n{release_line}")

--- a/pr_text_iwc.py
+++ b/pr_text_iwc.py
@@ -44,6 +44,11 @@ with open(args.log) as f:
             release_line = line
             text.append(f"\n{release_line}")
 
+# Add info on the strategy
+text.append("\nIf you want to skip this change, close this PR without deleting the branch. It will be reopened if another change is detected.")
+text.append("Any commit from another author than 'planemo-autoupdate' will prevent more auto-updates.")
+text.append("To ignore manual changes and allow autoupdates, delete the branch.")
+
 with open(args.out, "w") as f:
     f.write("\n".join(text))
 


### PR DESCRIPTION
I found 2 bugs.
First one is easy, if we do the `| head -n 1` then even if there is no output it will be `true`. I proposed a fix which is to do the `head -n 1` after.
The second one is relatively hard.
My strategy for workflows was that if the file `CHANGELOG.md` does not change, we do not push new commits but if it changes we force push. I forgot that the CHANGELOG.md contains the date... So if you run autoupdate on 2 different days it will consider changes while it is just the date which changed. I propose a fix which is to check if it is a workflow if there is a single line changing.
