### PR TITLE
Add new upstream repository for metabolomics tools

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -38,6 +38,11 @@ jobs:
             upstream_repo_name: galaxytools
             upstream_repo_branch: master
             upstream_repo_dir: tools/
+          - upstream_repo_owner: workflow4metabolomics
+            upstream_repo_name: tools-metabolomics
+            upstream_repo_branch: master
+            upstream_repo_dir: tools/
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo


### PR DESCRIPTION
This PR adds the tools-metabolomics repository from the workflow4metabolomics to the planemo autoupdate monitor